### PR TITLE
Implemented kernel extensions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,8 @@
 This file contains a list of the TODO tasks found within the source code.
 - **(`./cffi_build.py`)** Implement building the C library from Python
 - **(`./dependencies/OpenCL/include/CL/opencl.hpp`)** This should really have a D3D10 rerror code!
-- **(`./include/otto/cl/program.h`)** Implement creation of programs directly from source files
+- **(`./include/otto/cl/runtime.h`)** Add the option to load multiple kernel extensions
+- **(`./include/otto/cl/runtime.h`)** Include support for user-created kernel extensions
 - **(`./pysrc/otto/vector.py`)** Implement creation from arrays and lists
 - **(`./pysrc/otto/vector.py`)** Implement arithmetic operations using OpenCL kernels
 - **(`./pysrc/otto/vector.py`)** Implement interpreting as different collections (e.g. numpy arrays)

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,8 @@ This file contains a list of the TODO tasks found within the source code.
 - **(`./dependencies/OpenCL/include/CL/opencl.hpp`)** This should really have a D3D10 rerror code!
 - **(`./include/otto/cl/runtime.h`)** Add the option to load multiple kernel extensions
 - **(`./include/otto/cl/runtime.h`)** Include support for user-created kernel extensions
+- **(`./pysrc/otto_ffi/__init__.py`)** Update the FFI to account for the interface changes
+- **(`./pysrc/otto/vector.py`)** Update this class to account for the interface changes
 - **(`./pysrc/otto/vector.py`)** Implement creation from arrays and lists
 - **(`./pysrc/otto/vector.py`)** Implement arithmetic operations using OpenCL kernels
 - **(`./pysrc/otto/vector.py`)** Implement interpreting as different collections (e.g. numpy arrays)

--- a/examples/vector_add/main.c
+++ b/examples/vector_add/main.c
@@ -33,20 +33,6 @@ int main(void) {
     otto_vector_push(&b, &v);
   }
 
-  log_info("Loading the kernel");
-  FILE *fp;
-  char *source_str;
-  size_t source_size;
-  fp = fopen(OTTO_CLKERNEL("vector/elementary.cl"), "r");
-  if (!fp) {
-    fprintf(stderr, "Failed to load kernel.\n");
-    exit(1);
-  }
-  source_str = (char *)malloc(MAX_SOURCE_SIZE);
-  source_size = fread(source_str, 1, MAX_SOURCE_SIZE, fp);
-  log_debug("Source size: %d", source_size);
-  fclose(fp);
-
   log_info("Creating the runtime");
   otto_runtime_t ctx;
   otto_kernelht_t *ht = NULL;
@@ -62,10 +48,10 @@ int main(void) {
             "Failed registering OUT");
 
   log_info("Creating the program");
+  const char *files[] = {OTTO_CLKERNEL("vector/elementary.cl")};
   otto_program_t prog;
-  OTTO_CALL(
-      otto_program_from_sources(&ctx, (const char **)&source_str, 1, "", &prog),
-      "Failed to create the program");
+  OTTO_CALL(otto_program_from_files(&ctx, files, 1, "", &prog),
+            "Failed to create the program");
 
   log_info("Creating the kernel");
   OTTO_CALL(otto_kernel_new(&prog, "otto_vector_add", 3, &ctx, NULL),

--- a/examples/vector_add/main.c
+++ b/examples/vector_add/main.c
@@ -40,12 +40,9 @@ int main(void) {
             "Could not initialize the runtime");
 
   log_info("Creating the buffers in device memory");
-  OTTO_CALL(otto_vector_todevice(&a, &ctx, CL_MEM_READ_ONLY),
-            "Failed registering A");
-  OTTO_CALL(otto_vector_todevice(&b, &ctx, CL_MEM_READ_ONLY),
-            "Failed registering B");
-  OTTO_CALL(otto_vector_todevice(&out, &ctx, CL_MEM_WRITE_ONLY),
-            "Failed registering OUT");
+  OTTO_CALL(otto_vector_todevice_read(&a, &ctx), "Failed registering A");
+  OTTO_CALL(otto_vector_todevice_read(&b, &ctx), "Failed registering B");
+  OTTO_CALL(otto_vector_todevice_write(&out, &ctx), "Failed registering OUT");
 
   log_info("Creating the program");
   const char *files[] = {OTTO_CLKERNEL("vector/elementary.cl")};

--- a/examples/vector_add_clean/main.c
+++ b/examples/vector_add_clean/main.c
@@ -37,9 +37,9 @@ int main(void) {
   }
 
   log_info("Creating the buffers in device memory");
-  otto_vector_todevice(&a, &ctx, CL_MEM_READ_ONLY);
-  otto_vector_todevice(&b, &ctx, CL_MEM_READ_ONLY);
-  otto_vector_todevice(&out, &ctx, CL_MEM_WRITE_ONLY);
+  otto_vector_todevice_read(&a, &ctx);
+  otto_vector_todevice_read(&b, &ctx);
+  otto_vector_todevice_write(&out, &ctx);
 
   /* Call the kernel */
   log_info("Creating hparams");

--- a/examples/vector_add_clean/main.c
+++ b/examples/vector_add_clean/main.c
@@ -23,11 +23,7 @@ int main(void) {
   /* Loading kernels into the program */
   log_info("Creating the program");
   otto_program_t prog;
-  const char *files[] = {OTTO_CLKERNEL("vector/elementary.cl")};
-  otto_program_from_files(&ctx, files, 1, "", &prog);
-
-  log_info("Creating the kernel");
-  otto_kernel_new(&prog, "otto_vector_add", 3, &ctx, NULL);
+  otto_program_from_default(&ctx, OTTO_KERNELS_CORE, "", &prog);
   otto_program_cleanup(&prog);
 
   /* Create the vectors for the kernel call */

--- a/examples/vector_add_clean/main.c
+++ b/examples/vector_add_clean/main.c
@@ -13,8 +13,6 @@
 #include <otto/status.h>
 #include <otto/vector.h>
 
-#define MAX_SOURCE_SIZE (0x100000)
-
 int main(void) {
   /* Runtime creation */
   log_info("Creating the runtime");
@@ -23,23 +21,10 @@ int main(void) {
   otto_runtime_new(NULL, NULL, OTTO_DEVICE_GPU, ht, &ctx);
 
   /* Loading kernels into the program */
-  log_info("Loading the kernel");
-  FILE *fp;
-  char *source_str;
-  size_t source_size;
-  fp = fopen(OTTO_CLKERNEL("vector/elementary.cl"), "r");
-  if (!fp) {
-    fprintf(stderr, "Failed to load kernel.\n");
-    exit(1);
-  }
-  source_str = (char *)malloc(MAX_SOURCE_SIZE);
-  source_size = fread(source_str, 1, MAX_SOURCE_SIZE, fp);
-  log_debug("Source size: %d", source_size);
-  fclose(fp);
-
   log_info("Creating the program");
   otto_program_t prog;
-  otto_program_from_sources(&ctx, (const char **)&source_str, 1, "", &prog);
+  const char *files[] = {OTTO_CLKERNEL("vector/elementary.cl")};
+  otto_program_from_files(&ctx, files, 1, "", &prog);
 
   log_info("Creating the kernel");
   otto_kernel_new(&prog, "otto_vector_add", 3, &ctx, NULL);

--- a/examples/vector_add_clean/main.c
+++ b/examples/vector_add_clean/main.c
@@ -19,12 +19,7 @@ int main(void) {
   otto_runtime_t ctx;
   otto_kernelht_t *ht = NULL;
   otto_runtime_new(NULL, NULL, OTTO_DEVICE_GPU, ht, &ctx);
-
-  /* Loading kernels into the program */
-  log_info("Creating the program");
-  otto_program_t prog;
-  otto_program_from_default(&ctx, OTTO_KERNELS_CORE, "", &prog);
-  otto_program_cleanup(&prog);
+  otto_runtime_load_kernels(&ctx, OTTO_KERNELS_CORE, "");
 
   /* Create the vectors for the kernel call */
   log_info("Creating the vectors");

--- a/examples/vector_add_clean/main.c
+++ b/examples/vector_add_clean/main.c
@@ -35,11 +35,12 @@ int main(void) {
     int v = LIST_SIZE - i;
     otto_vector_push(&b, &v);
   }
+  otto_vector_setwrite(&out);
 
   log_info("Creating the buffers in device memory");
-  otto_vector_todevice_read(&a, &ctx);
-  otto_vector_todevice_read(&b, &ctx);
-  otto_vector_todevice_write(&out, &ctx);
+  otto_vector_todevice(&a, &ctx);
+  otto_vector_todevice(&b, &ctx);
+  otto_vector_todevice(&out, &ctx);
 
   /* Call the kernel */
   log_info("Creating hparams");

--- a/include/otto/cl/program.h
+++ b/include/otto/cl/program.h
@@ -18,6 +18,7 @@ typedef struct otto_program {
 } otto_program_t;
 
 typedef enum otto_program_kernels {
+  OTTO_KERNELS_ALL,
   OTTO_KERNELS_CORE,
 } otto_program_kernels_t;
 

--- a/include/otto/cl/program.h
+++ b/include/otto/cl/program.h
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 
+#include <otto/paths.h>
 #include <otto/status.h>
 
 #include "cl.h"
@@ -16,6 +17,10 @@ typedef struct otto_program {
   cl_program p;
 } otto_program_t;
 
+typedef enum otto_program_kernels {
+  OTTO_KERNELS_CORE,
+} otto_program_kernels_t;
+
 otto_status_t otto_program_from_sources(const otto_runtime_t *ctx,
                                         const char **sources,
                                         const size_t count,
@@ -25,14 +30,16 @@ otto_status_t otto_program_from_files(otto_runtime_t *ctx, const char **files,
                                       const size_t count,
                                       const char *build_options,
                                       otto_program_t *out);
+otto_status_t otto_program_from_default(otto_runtime_t *ctx,
+                                        const otto_program_kernels_t kernels,
+                                        const char *build_options,
+                                        otto_program_t *out);
 
 otto_status_t otto_program_cleanup(const otto_program_t *prog);
 
 otto_status_t otto_program_build(const otto_program_t *prog,
                                  const otto_runtime_t *ctx,
                                  const char *options);
-
-// TODO: Implement creation of programs directly from source files
 
 #ifdef __cplusplus
 }

--- a/include/otto/cl/program.h
+++ b/include/otto/cl/program.h
@@ -21,6 +21,10 @@ otto_status_t otto_program_from_sources(const otto_runtime_t *ctx,
                                         const size_t count,
                                         const char *build_options,
                                         otto_program_t *out);
+otto_status_t otto_program_from_files(otto_runtime_t *ctx, const char **files,
+                                      const size_t count,
+                                      const char *build_options,
+                                      otto_program_t *out);
 
 otto_status_t otto_program_cleanup(const otto_program_t *prog);
 

--- a/include/otto/cl/runtime.h
+++ b/include/otto/cl/runtime.h
@@ -5,6 +5,7 @@
 #include <uthash.h>
 
 #include <otto/cl/cl.h>
+#include <otto/cl/program.h>
 #include <otto/devices.h>
 #include <otto/status.h>
 
@@ -67,6 +68,9 @@ otto_status_t otto_runtime_new(const cl_context_properties *ctx_props,
                                const cl_queue_properties *q_props,
                                const otto_device_t type,
                                otto_kernelht_t *kernel_ht, otto_runtime_t *out);
+otto_status_t otto_runtime_load_kernels(otto_runtime_t *ctx,
+                                        const otto_program_kernels_t kernels,
+                                        const char *build_options);
 
 otto_status_t otto_runtime_cleanup(const otto_runtime_t *ctx);
 

--- a/include/otto/cl/runtime.h
+++ b/include/otto/cl/runtime.h
@@ -59,6 +59,8 @@ typedef struct otto_runtime {
   otto_kernelht_t *_kernels_ht;
   otto_kernelll_t *_kernels_ll;
   otto_kernel_args_t *kernel_hparams;
+  const char **_sources; // Keeps track of them only to clean them up
+  size_t _sources_count; // Keeps track of them only to clean them up
 } otto_runtime_t;
 
 otto_status_t otto_runtime_new(const cl_context_properties *ctx_props,

--- a/include/otto/cl/runtime.h
+++ b/include/otto/cl/runtime.h
@@ -72,6 +72,9 @@ otto_status_t otto_runtime_load_kernels(otto_runtime_t *ctx,
                                         const otto_program_kernels_t kernels,
                                         const char *build_options);
 
+// TODO: Add the option to load multiple kernel extensions
+// TODO: Include support for user-created kernel extensions
+
 otto_status_t otto_runtime_cleanup(const otto_runtime_t *ctx);
 
 otto_status_t otto_runtime_add_kernel(otto_runtime_t *ctx, const char *name,

--- a/include/otto/vector.h
+++ b/include/otto/vector.h
@@ -27,6 +27,7 @@ typedef struct otto_vector {
   size_t capacity;
   otto_device_t device;
   const otto_runtime_t *ctx;
+  cl_mem_flags flags;
 } otto_vector_t;
 
 /* Vector creation */
@@ -57,6 +58,10 @@ otto_status_t otto_vector_extend_array(otto_vector_t *vec, const void *src,
                                        const size_t len);
 
 /* Vector movements */
+
+otto_status_t otto_vector_setread(otto_vector_t *vec);
+otto_status_t otto_vector_setwrite(otto_vector_t *vec);
+otto_status_t otto_vector_setreadwrite(otto_vector_t *vec);
 
 otto_status_t otto_vector_todevice_mode(otto_vector_t *vec,
                                         const otto_runtime_t *ctx,

--- a/include/otto/vector.h
+++ b/include/otto/vector.h
@@ -58,9 +58,15 @@ otto_status_t otto_vector_extend_array(otto_vector_t *vec, const void *src,
 
 /* Vector movements */
 
+otto_status_t otto_vector_todevice_mode(otto_vector_t *vec,
+                                        const otto_runtime_t *ctx,
+                                        const cl_mem_flags flags);
 otto_status_t otto_vector_todevice(otto_vector_t *vec,
-                                   const otto_runtime_t *ctx,
-                                   const cl_mem_flags flags);
+                                   const otto_runtime_t *ctx);
+otto_status_t otto_vector_todevice_read(otto_vector_t *vec,
+                                        const otto_runtime_t *ctx);
+otto_status_t otto_vector_todevice_write(otto_vector_t *vec,
+                                         const otto_runtime_t *ctx);
 otto_status_t otto_vector_tohost(otto_vector_t *vec, uint64_t total);
 
 #ifdef __cplusplus

--- a/pysrc/otto/vector.py
+++ b/pysrc/otto/vector.py
@@ -6,6 +6,9 @@ import otto_ffi as _
 from _otto import ffi, lib as _ottol
 
 
+# TODO: Update this class to account for the interface changes
+
+
 class Vector[T]:
     __slots__ = ("_cdata", "_dtype", "_dsize", "_index")
 

--- a/pysrc/otto_ffi/__init__.py
+++ b/pysrc/otto_ffi/__init__.py
@@ -16,3 +16,6 @@ except KeyError:
 _WINDOWS_NAME = "nt"
 if os.name == _WINDOWS_NAME:
     os.add_dll_directory(os.environ["LD_LIBRARY_PATH"])
+
+
+# TODO: Update the FFI to account for the interface changes

--- a/src/otto_core/cl/program.c
+++ b/src/otto_core/cl/program.c
@@ -4,12 +4,28 @@
 #include <string.h>
 
 #include <otto/cl/cl.h>
+#include <otto/cl/kernel.h>
 #include <otto/cl/program.h>
 #include <otto/cl/runtime.h>
 #include <otto/status.h>
 
 #include <otto_utils/macros.h>
 #include <otto_utils/vendor/log.h>
+
+const char *_OTTO_KERNELS_CORE[] = {
+    OTTO_CLKERNEL("vector/elementary.cl"),
+    OTTO_CLKERNEL("matrix/elementary.cl"),
+};
+const char *_OTTO_KERNELS_CORE_NAMES[] = {
+    // Vectors
+    "otto_vector_add", "otto_vector_sub", "otto_vector_mul", "otto_vector_div",
+
+    // Matrices
+};
+const size_t _OTTO_KERNELS_CORE_COUNT =
+    sizeof(_OTTO_KERNELS_CORE) / sizeof(char *);
+const size_t _OTTO_KERNELS_CORE_NAMES_COUNT =
+    sizeof(_OTTO_KERNELS_CORE_NAMES) / sizeof(char *);
 
 int64_t get_file_size(FILE *file) {
   fseek(file, 0, SEEK_END);
@@ -56,6 +72,10 @@ otto_status_t otto_program_from_files(otto_runtime_t *ctx, const char **files,
                                       const char *build_options,
                                       otto_program_t *out) {
   char **sources = malloc(count * sizeof(char *));
+  if (sources == NULL) {
+    logi_error("Could not allocate files");
+    return OTTO_STATUS_FAILURE;
+  }
   FILE *f;
   char *source;
   int64_t size = 0;
@@ -71,6 +91,10 @@ otto_status_t otto_program_from_files(otto_runtime_t *ctx, const char **files,
     size = get_file_size(f);
     logi_debug("File size: %i", size);
     source = malloc(size * sizeof(char));
+    if (source == NULL) {
+      logi_warn("Could not allocate contents");
+      continue;
+    }
     fread(source, 1, size, f);
     source[size] = 0;
     fclose(f);
@@ -83,6 +107,42 @@ otto_status_t otto_program_from_files(otto_runtime_t *ctx, const char **files,
   ctx->_sources_count = count;
   return otto_program_from_sources(ctx, (const char **)sources, count,
                                    build_options, out);
+}
+
+otto_status_t otto_program_from_default(otto_runtime_t *ctx,
+                                        const otto_program_kernels_t kernels,
+                                        const char *build_options,
+                                        otto_program_t *out) {
+  const char **files;
+  const char **ker_names;
+  size_t count;
+  size_t ker_count;
+  switch (kernels) {
+  case OTTO_KERNELS_CORE:
+    files = _OTTO_KERNELS_CORE;
+    count = _OTTO_KERNELS_CORE_COUNT;
+    ker_names = _OTTO_KERNELS_CORE_NAMES;
+    ker_count = _OTTO_KERNELS_CORE_NAMES_COUNT;
+    logi_info("Using CORE kernels");
+    break;
+
+  default:
+    logi_error("Could not interpret kernels");
+    return OTTO_STATUS_FAILURE;
+  }
+
+  logi_debug("Loading %i files", count);
+  logi_debug("Loading %i kernels", ker_count);
+
+  OTTO_CALL_I(otto_program_from_files(ctx, files, count, build_options, out),
+              "Could not create program from files");
+
+  // Since we know the kernels we can create them right away
+  for (size_t i = 0; i < ker_count; i++, ker_names++) {
+    OTTO_CALL_I(otto_kernel_new(out, *ker_names, 3, ctx, NULL),
+                "Could not load kernel '%s'", *ker_names);
+  }
+  return OTTO_STATUS_SUCCESS;
 }
 
 otto_status_t otto_program_cleanup(const otto_program_t *prog) {

--- a/src/otto_core/cl/program.c
+++ b/src/otto_core/cl/program.c
@@ -19,13 +19,26 @@ const char *_OTTO_KERNELS_CORE[] = {
 const char *_OTTO_KERNELS_CORE_NAMES[] = {
     // Vectors
     "otto_vector_add", "otto_vector_sub", "otto_vector_mul", "otto_vector_div",
-
     // Matrices
 };
 const size_t _OTTO_KERNELS_CORE_COUNT =
     sizeof(_OTTO_KERNELS_CORE) / sizeof(char *);
 const size_t _OTTO_KERNELS_CORE_NAMES_COUNT =
     sizeof(_OTTO_KERNELS_CORE_NAMES) / sizeof(char *);
+
+const char *_OTTO_KERNELS_ALL[] = {
+    OTTO_CLKERNEL("vector/elementary.cl"),
+    OTTO_CLKERNEL("matrix/elementary.cl"),
+};
+const char *_OTTO_KERNELS_ALL_NAMES[] = {
+    // Vectors
+    "otto_vector_add", "otto_vector_sub", "otto_vector_mul", "otto_vector_div",
+    // Matrices
+};
+const size_t _OTTO_KERNELS_ALL_COUNT =
+    sizeof(_OTTO_KERNELS_ALL) / sizeof(char *);
+const size_t _OTTO_KERNELS_ALL_NAMES_COUNT =
+    sizeof(_OTTO_KERNELS_ALL_NAMES) / sizeof(char *);
 
 int64_t get_file_size(FILE *file) {
   fseek(file, 0, SEEK_END);
@@ -124,6 +137,14 @@ otto_status_t otto_program_from_default(otto_runtime_t *ctx,
     ker_names = _OTTO_KERNELS_CORE_NAMES;
     ker_count = _OTTO_KERNELS_CORE_NAMES_COUNT;
     logi_info("Using CORE kernels");
+    break;
+
+  case OTTO_KERNELS_ALL:
+    files = _OTTO_KERNELS_ALL;
+    count = _OTTO_KERNELS_ALL_COUNT;
+    ker_names = _OTTO_KERNELS_ALL_NAMES;
+    ker_count = _OTTO_KERNELS_ALL_NAMES_COUNT;
+    logi_info("Using ALL kernels");
     break;
 
   default:

--- a/src/otto_core/cl/runtime.c
+++ b/src/otto_core/cl/runtime.c
@@ -10,6 +10,7 @@
 
 #include <otto/cl/cl.h>
 #include <otto/cl/kernel.h>
+#include <otto/cl/program.h>
 #include <otto/cl/runtime.h>
 #include <otto/devices.h>
 #include <otto/status.h>
@@ -90,6 +91,16 @@ otto_status_t otto_runtime_new(const cl_context_properties *ctx_props,
       ._sources_count = 0,
   };
   *out = result;
+  return OTTO_STATUS_SUCCESS;
+}
+
+otto_status_t otto_runtime_load_kernels(otto_runtime_t *ctx,
+                                        const otto_program_kernels_t kernels,
+                                        const char *build_options) {
+  otto_program_t prog;
+  OTTO_CALL_I(otto_program_from_default(ctx, kernels, build_options, &prog),
+              "Could not load program");
+  OTTO_CALL_I(otto_program_cleanup(&prog), "Failed cleaning up the program");
   return OTTO_STATUS_SUCCESS;
 }
 

--- a/src/otto_core/vector_creation.c
+++ b/src/otto_core/vector_creation.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <otto/cl/cl.h>
 #include <otto/status.h>
 #include <otto/vector.h>
 #include <otto_utils/macros.h>
@@ -15,6 +16,7 @@ otto_status_t otto_vector_new(const size_t data_size, otto_vector_t *out) {
       .capacity = 0,
       .device = OTTO_DEVICE_CPU,
       .ctx = NULL,
+      .flags = CL_MEM_READ_ONLY,
   };
   *out = result;
   return OTTO_STATUS_SUCCESS;
@@ -35,6 +37,7 @@ otto_status_t otto_vector_zero(const size_t len, const size_t data_size,
       .capacity = len,
       .device = OTTO_DEVICE_CPU,
       .ctx = NULL,
+      .flags = CL_MEM_READ_ONLY,
   };
   *out = result;
   return OTTO_STATUS_SUCCESS;
@@ -56,6 +59,7 @@ otto_status_t otto_vector_with_capacity(const size_t capacity,
       .capacity = capacity,
       .device = OTTO_DEVICE_CPU,
       .ctx = NULL,
+      .flags = CL_MEM_READ_ONLY,
   };
   *out = result;
   return OTTO_STATUS_SUCCESS;
@@ -78,6 +82,7 @@ otto_status_t otto_vector_from_array(const void *data, const size_t len,
       .capacity = len,
       .device = OTTO_DEVICE_CPU,
       .ctx = NULL,
+      .flags = CL_MEM_READ_ONLY,
   };
   *out = result;
   return OTTO_STATUS_SUCCESS;

--- a/src/otto_core/vector_dev.c
+++ b/src/otto_core/vector_dev.c
@@ -8,6 +8,21 @@
 #include <otto_utils/macros.h>
 #include <otto_utils/vendor/log.h>
 
+otto_status_t otto_vector_setread(otto_vector_t *vec) {
+  vec->flags = CL_MEM_READ_ONLY;
+  return OTTO_STATUS_SUCCESS;
+}
+
+otto_status_t otto_vector_setwrite(otto_vector_t *vec) {
+  vec->flags = CL_MEM_WRITE_ONLY;
+  return OTTO_STATUS_SUCCESS;
+}
+
+otto_status_t otto_vector_setreadwrite(otto_vector_t *vec) {
+  vec->flags = CL_MEM_READ_WRITE;
+  return OTTO_STATUS_SUCCESS;
+}
+
 otto_status_t otto_vector_todevice_mode(otto_vector_t *vec,
                                         const otto_runtime_t *ctx,
                                         const cl_mem_flags flags) {
@@ -46,7 +61,7 @@ otto_status_t otto_vector_todevice_mode(otto_vector_t *vec,
 
 otto_status_t otto_vector_todevice(otto_vector_t *vec,
                                    const otto_runtime_t *ctx) {
-  return otto_vector_todevice_mode(vec, ctx, CL_MEM_READ_WRITE);
+  return otto_vector_todevice_mode(vec, ctx, vec->flags);
 }
 
 otto_status_t otto_vector_todevice_read(otto_vector_t *vec,

--- a/src/otto_core/vector_dev.c
+++ b/src/otto_core/vector_dev.c
@@ -8,9 +8,9 @@
 #include <otto_utils/macros.h>
 #include <otto_utils/vendor/log.h>
 
-otto_status_t otto_vector_todevice(otto_vector_t *vec,
-                                   const otto_runtime_t *ctx,
-                                   const cl_mem_flags flags) {
+otto_status_t otto_vector_todevice_mode(otto_vector_t *vec,
+                                        const otto_runtime_t *ctx,
+                                        const cl_mem_flags flags) {
   const char *dev_name;
   OTTO_CALL_I(otto_device_name(ctx->dev, &dev_name),
               "Requested device not implemented");
@@ -42,6 +42,21 @@ otto_status_t otto_vector_todevice(otto_vector_t *vec,
   vec->device = ctx->dev;
   vec->ctx = ctx;
   return OTTO_STATUS_SUCCESS;
+}
+
+otto_status_t otto_vector_todevice(otto_vector_t *vec,
+                                   const otto_runtime_t *ctx) {
+  return otto_vector_todevice_mode(vec, ctx, CL_MEM_READ_WRITE);
+}
+
+otto_status_t otto_vector_todevice_read(otto_vector_t *vec,
+                                        const otto_runtime_t *ctx) {
+  return otto_vector_todevice_mode(vec, ctx, CL_MEM_READ_ONLY);
+}
+
+otto_status_t otto_vector_todevice_write(otto_vector_t *vec,
+                                         const otto_runtime_t *ctx) {
+  return otto_vector_todevice_mode(vec, ctx, CL_MEM_READ_ONLY);
 }
 
 otto_status_t otto_vector_tohost(otto_vector_t *vec, uint64_t total) {


### PR DESCRIPTION
Currently it is not too extendible, but it provides a framework to expand upon. The idea is that, eventually, the user might pass user-defined collections of kernels (a *kernel extension*) when creating the runtime, thus giving an easy way to access their kernels.